### PR TITLE
Implement data ingestion pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+regradar.db
+

--- a/regradar/__init__.py
+++ b/regradar/__init__.py
@@ -1,0 +1,1 @@
+"""RegRadar package implementing data ingestion pipeline."""

--- a/regradar/database.py
+++ b/regradar/database.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+# SQLite database stored in the project directory
+DATABASE_URL = "sqlite:///regradar.db"
+
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+class Source(Base):
+    __tablename__ = "source"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    url = Column(String, nullable=False, unique=True)
+
+    documents = relationship("Document", back_populates="source")
+
+
+class Document(Base):
+    __tablename__ = "document"
+
+    id = Column(Integer, primary_key=True)
+    external_id = Column(String, nullable=False, unique=True)
+    source_id = Column(Integer, ForeignKey("source.id"), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    source = relationship("Source", back_populates="documents")
+    versions = relationship("DocumentVersion", back_populates="document")
+
+
+class DocumentVersion(Base):
+    __tablename__ = "document_version"
+
+    id = Column(Integer, primary_key=True)
+    document_id = Column(Integer, ForeignKey("document.id"), nullable=False)
+    content_hash = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (UniqueConstraint("content_hash"),)
+
+    document = relationship("Document", back_populates="versions")
+    events = relationship("ChangeEvent", back_populates="version", foreign_keys="ChangeEvent.document_version_id")
+
+
+class ChangeEvent(Base):
+    __tablename__ = "change_event"
+
+    id = Column(Integer, primary_key=True)
+    document_version_id = Column(Integer, ForeignKey("document_version.id"), nullable=False)
+    previous_version_id = Column(Integer, ForeignKey("document_version.id"))
+    diff = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    version = relationship("DocumentVersion", foreign_keys=[document_version_id])
+    previous = relationship("DocumentVersion", foreign_keys=[previous_version_id])
+
+
+# Helper dataclasses used by nodes
+@dataclass
+class RawDoc:
+    url: str
+    content: bytes
+    source_id: int
+    title: str | None = None
+
+
+@dataclass
+class ParsedDoc:
+    url: str
+    text: str
+    source_id: int
+    title: str | None = None
+
+
+@dataclass
+class HashStoreResult:
+    document: Document
+    version: DocumentVersion
+    is_new_version: bool
+
+
+def init_db() -> None:
+    """Create tables and seed the source table with a few entries."""
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    try:
+        if session.query(Source).count() == 0:
+            sources = [
+                ("EUR-Lex", "https://eur-lex.europa.eu/rss/fr/daily-rss.xml"),
+                ("W3C News", "https://www.w3.org/blog/news/feed/"),
+                ("Hacker News", "https://news.ycombinator.com/rss"),
+                ("UN News", "https://news.un.org/feed/subscribe/en/news/all/rss.xml"),
+                ("EU Press", "https://ec.europa.eu/commission/presscorner/home/en/rss.xml"),
+            ]
+            for name, url in sources:
+                session.add(Source(name=name, url=url))
+            session.commit()
+    finally:
+        session.close()

--- a/regradar/nodes.py
+++ b/regradar/nodes.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import difflib
+import io
+import xml.etree.ElementTree as ET
+from typing import Iterable, List, Optional
+
+import httpx
+import trafilatura
+from pypdf import PdfReader
+
+from .database import (
+    ChangeEvent,
+    Document,
+    DocumentVersion,
+    HashStoreResult,
+    ParsedDoc,
+    RawDoc,
+    SessionLocal,
+    Source,
+)
+
+USER_AGENT = "RegRadarBot/0.1"
+TIMEOUT = 10.0
+
+
+def fetch_sources() -> List[Source]:
+    """Return all sources from the database."""
+    session = SessionLocal()
+    try:
+        return session.query(Source).all()
+    finally:
+        session.close()
+
+
+def fetch_documents(sources: Iterable[Source]) -> List[RawDoc]:
+    """Download documents for the given sources (RSS feeds)."""
+    client = httpx.Client(headers={"User-Agent": USER_AGENT}, timeout=TIMEOUT)
+    raw_docs: List[RawDoc] = []
+    for source in sources:
+        try:
+            resp = client.get(source.url)
+            resp.raise_for_status()
+        except Exception:
+            continue
+        try:
+            root = ET.fromstring(resp.content)
+        except ET.ParseError:
+            continue
+        # Find item links in RSS feed
+        for item in root.findall('.//item')[:5]:
+            link_el = item.find('link')
+            title_el = item.find('title')
+            if link_el is None:
+                continue
+            link = link_el.text.strip()
+            title = title_el.text.strip() if title_el is not None else None
+            try:
+                doc_resp = client.get(link)
+                doc_resp.raise_for_status()
+                raw_docs.append(RawDoc(url=link, content=doc_resp.content, source_id=source.id, title=title))
+            except Exception:
+                continue
+    client.close()
+    return raw_docs
+
+
+def parse_document(raw_doc: RawDoc) -> ParsedDoc:
+    """Extract text and metadata from raw document."""
+    if raw_doc.url.lower().endswith('.pdf'):
+        reader = PdfReader(io.BytesIO(raw_doc.content))
+        text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    else:
+        text = trafilatura.extract(raw_doc.content.decode('utf-8', errors='ignore')) or ""
+    return ParsedDoc(url=raw_doc.url, text=text, source_id=raw_doc.source_id, title=raw_doc.title)
+
+
+def hash_and_store(parsed_doc: ParsedDoc) -> HashStoreResult:
+    session = SessionLocal()
+    try:
+        content_hash = hashlib.sha256(parsed_doc.text.encode('utf-8')).hexdigest()
+        document = session.query(Document).filter_by(external_id=parsed_doc.url).first()
+        if document is None:
+            document = Document(external_id=parsed_doc.url, source_id=parsed_doc.source_id)
+            session.add(document)
+            session.commit()
+        version = session.query(DocumentVersion).filter_by(content_hash=content_hash, document_id=document.id).first()
+        is_new = False
+        if version is None:
+            version = DocumentVersion(document_id=document.id, content_hash=content_hash, content=parsed_doc.text)
+            session.add(version)
+            session.commit()
+            is_new = True
+        return HashStoreResult(document=document, version=version, is_new_version=is_new)
+    finally:
+        session.close()
+
+
+def link_versions(result: HashStoreResult) -> Optional[DocumentVersion]:
+    if not result.is_new_version:
+        return None
+    session = SessionLocal()
+    try:
+        previous = (
+            session.query(DocumentVersion)
+            .filter(
+                DocumentVersion.document_id == result.document.id,
+                DocumentVersion.id < result.version.id,
+            )
+            .order_by(DocumentVersion.id.desc())
+            .first()
+        )
+        return previous
+    finally:
+        session.close()
+
+
+def compute_diff(result: HashStoreResult, previous: Optional[DocumentVersion]) -> Optional[ChangeEvent]:
+    if previous is None or not result.is_new_version:
+        return None
+    session = SessionLocal()
+    try:
+        diff_lines = difflib.unified_diff(
+            previous.content.splitlines(),
+            result.version.content.splitlines(),
+            lineterm="",
+        )
+        diff_text = "\n".join(diff_lines)
+        event = ChangeEvent(
+            document_version_id=result.version.id,
+            previous_version_id=previous.id,
+            diff=diff_text,
+        )
+        session.add(event)
+        session.commit()
+        return event
+    finally:
+        session.close()

--- a/regradar/pipeline.py
+++ b/regradar/pipeline.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from .database import init_db
+from .nodes import (
+    compute_diff,
+    fetch_documents,
+    fetch_sources,
+    hash_and_store,
+    link_versions,
+    parse_document,
+)
+
+
+def build_graph() -> StateGraph:
+    graph = StateGraph(dict)
+    graph.add_node("fetch_sources", lambda state: {"sources": fetch_sources()})
+
+    def fetch_docs_node(state):
+        docs = fetch_documents(state["sources"])
+        return {"raw_docs": docs}
+
+    def parse_node(state):
+        parsed = [parse_document(doc) for doc in state["raw_docs"]]
+        return {"parsed_docs": parsed}
+
+    def store_node(state):
+        results = [hash_and_store(doc) for doc in state["parsed_docs"]]
+        return {"results": results}
+
+    def link_node(state):
+        prevs = [link_versions(res) for res in state["results"]]
+        return {"prevs": prevs}
+
+    def diff_node(state):
+        events = [
+            compute_diff(res, prev)
+            for res, prev in zip(state["results"], state["prevs"])
+        ]
+        return {"events": events}
+
+    graph.add_node("fetch_documents", fetch_docs_node)
+    graph.add_node("parse_document", parse_node)
+    graph.add_node("hash_and_store", store_node)
+    graph.add_node("link_versions", link_node)
+    graph.add_node("compute_diff", diff_node)
+
+    graph.add_edge("fetch_sources", "fetch_documents")
+    graph.add_edge("fetch_documents", "parse_document")
+    graph.add_edge("parse_document", "hash_and_store")
+    graph.add_edge("hash_and_store", "link_versions")
+    graph.add_edge("link_versions", "compute_diff")
+    graph.add_edge("compute_diff", END)
+
+    graph.set_entry_point("fetch_sources")
+    return graph
+
+
+def run() -> None:
+    init_db()
+    graph = build_graph()
+    app = graph.compile()
+    app.invoke({})
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and seed sources for ingestion
- implement nodes to fetch, parse, store, link, and diff documents
- assemble nodes into a LangGraph pipeline

## Testing
- `pip install httpx trafilatura pypdf langgraph sqlalchemy` *(fails: Could not find a version that satisfies the requirement httpx)*
- `python -m regradar.pipeline` *(fails: ModuleNotFoundError: No module named 'langgraph')*


------
https://chatgpt.com/codex/tasks/task_e_689a1605fea0832e90669128c816d615