### PR TITLE
Add AI classification and publishing pipeline

### DIFF
--- a/prompts/classify.txt
+++ b/prompts/classify.txt
@@ -1,0 +1,8 @@
+You are an assistant that classifies regulatory document changes.
+Respond with a JSON object containing:
+- "category": a short label
+- "priority": one of low, medium, high
+- "confidence": a float between 0 and 1
+
+Diff:
+{text}

--- a/prompts/guard.txt
+++ b/prompts/guard.txt
@@ -1,0 +1,8 @@
+You validate that all URLs mentioned in the summary are present in the source document.
+Return JSON {"citations_valid": true|false}.
+
+Document:
+{document}
+
+Summary:
+{summary}

--- a/prompts/summarize_impact.txt
+++ b/prompts/summarize_impact.txt
@@ -1,0 +1,8 @@
+You are an assistant summarizing the impact of regulatory document changes.
+Return a JSON object with:
+- "summary": brief summary of the change
+- "actions": list of recommended follow-up actions
+- "citations": list of URLs referenced in the summary
+
+Document:
+{text}

--- a/regradar/database.py
+++ b/regradar/database.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    Float,
     UniqueConstraint,
     create_engine,
 )
@@ -73,6 +74,19 @@ class ChangeEvent(Base):
 
     version = relationship("DocumentVersion", foreign_keys=[document_version_id])
     previous = relationship("DocumentVersion", foreign_keys=[previous_version_id])
+
+
+class ImpactAssessment(Base):
+    __tablename__ = "impact_assessment"
+
+    id = Column(Integer, primary_key=True)
+    document_version_id = Column(Integer, ForeignKey("document_version.id"), nullable=False)
+    summary = Column(Text)
+    actions = Column(Text)
+    score = Column(Float)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    version = relationship("DocumentVersion")
 
 
 # Helper dataclasses used by nodes

--- a/regradar/pipeline.py
+++ b/regradar/pipeline.py
@@ -10,6 +10,12 @@ from .nodes import (
     hash_and_store,
     link_versions,
     parse_document,
+    classify,
+    summarize_impact,
+    guard_citations,
+    score_priority,
+    publish,
+    human_review,
 )
 
 
@@ -34,24 +40,78 @@ def build_graph() -> StateGraph:
         return {"prevs": prevs}
 
     def diff_node(state):
-        events = [
-            compute_diff(res, prev)
-            for res, prev in zip(state["results"], state["prevs"])
-        ]
-        return {"events": events}
+        for res, prev in zip(state["results"], state["prevs"]):
+            event = compute_diff(res, prev)
+            if event is not None:
+                return {"event": event, "result": res}
+        return {}
+
+    def classify_node(state):
+        if "event" not in state:
+            return {}
+        return {"classification": classify(state["event"].diff)}
+
+    def summarize_node(state):
+        if "event" not in state:
+            return {}
+        text = state["result"].version.content
+        return {"summary": summarize_impact(text)}
+
+    def guard_node(state):
+        if "event" not in state:
+            return {}
+        text = state["result"].version.content
+        return {"guard": guard_citations(text, state["summary"])}
+
+    def score_node(state):
+        if "classification" not in state:
+            return {}
+        return {"score": score_priority(state["classification"])}
+
+    def publish_node(state):
+        if "event" not in state:
+            return {}
+        publish(state["result"], state["summary"], state["score"])
+        return {}
+
+    def review_node(state):
+        return human_review(state)
+
+    def qc_gate(state):
+        if "event" not in state:
+            return "human_review"
+        if not state["guard"].get("guard_passed"):
+            return "human_review"
+        if state["classification"].get("confidence", 0) < 0.7:
+            return "human_review"
+        return "publish"
 
     graph.add_node("fetch_documents", fetch_docs_node)
     graph.add_node("parse_document", parse_node)
     graph.add_node("hash_and_store", store_node)
     graph.add_node("link_versions", link_node)
     graph.add_node("compute_diff", diff_node)
+    graph.add_node("classify", classify_node)
+    graph.add_node("summarize_impact", summarize_node)
+    graph.add_node("guard_citations", guard_node)
+    graph.add_node("score_priority", score_node)
+    graph.add_node("publish", publish_node)
+    graph.add_node("human_review", review_node)
 
     graph.add_edge("fetch_sources", "fetch_documents")
     graph.add_edge("fetch_documents", "parse_document")
     graph.add_edge("parse_document", "hash_and_store")
     graph.add_edge("hash_and_store", "link_versions")
     graph.add_edge("link_versions", "compute_diff")
-    graph.add_edge("compute_diff", END)
+    graph.add_edge("compute_diff", "classify")
+    graph.add_edge("compute_diff", "summarize_impact")
+    graph.add_edge("classify", "score_priority")
+    graph.add_edge("summarize_impact", "guard_citations")
+    graph.add_edge("score_priority", "qc_gate")
+    graph.add_edge("guard_citations", "qc_gate")
+    graph.add_conditional_edges("qc_gate", qc_gate, {"publish": "publish", "human_review": "human_review"})
+    graph.add_edge("publish", END)
+    graph.add_edge("human_review", END)
 
     graph.set_entry_point("fetch_sources")
     return graph

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ trafilatura==1.7.0
 pypdf==3.17.1
 langgraph==0.0.20
 PyYAML==6.0.1
+openai>=1.0.0
+SQLAlchemy>=2.0.0


### PR DESCRIPTION
## Summary
- add OpenAI-powered classify and summarization nodes with prompts
- guard citations, score priority, and publish impact assessments
- route workflow through QC gate to publish or human review

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai>=1.0.0)*
- `python -m py_compile regradar/nodes.py regradar/pipeline.py regradar/database.py`
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689a32ada2bc832e8e4c0aab5ae2c021