### PR TITLE
Use API key for frontend API calls and handle empty change list

### DIFF
--- a/frontend/app/impact/[id]/page.tsx
+++ b/frontend/app/impact/[id]/page.tsx
@@ -22,7 +22,7 @@ export default function ImpactPage() {
       return;
     }
     fetch((process.env.NEXT_PUBLIC_API_URL || '') + `/v1/impacts/${id}`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { 'X-API-Key': token },
     })
       .then((res) => res.json())
       .then(setAssessment)
@@ -43,10 +43,12 @@ export default function ImpactPage() {
           ))}
         </ul>
       </section>
-      <section>
-        <h2 className="text-xl font-semibold">Diff</h2>
-        <pre className="bg-gray-200 p-2 overflow-auto">{assessment.diff}</pre>
-      </section>
+      {assessment.diff && (
+        <section>
+          <h2 className="text-xl font-semibold">Diff</h2>
+          <pre className="bg-gray-200 p-2 overflow-auto">{assessment.diff}</pre>
+        </section>
+      )}
     </main>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -18,23 +18,27 @@ export default function HomePage() {
       return;
     }
     fetch((process.env.NEXT_PUBLIC_API_URL || '') + '/v1/changes', {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { 'X-API-Key': token },
     })
       .then((res) => res.json())
-      .then(setChanges)
+      .then((data) => setChanges(data.items || []))
       .catch(() => setChanges([]));
   }, []);
 
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold mb-4">Recent Regulatory Changes</h1>
-      <ul className="space-y-2">
-        {changes.map((change) => (
-          <li key={change.id} className="p-2 border rounded">
-            <Link href={`/impact/${change.id}`}>{change.summary}</Link>
-          </li>
-        ))}
-      </ul>
+      {changes.length === 0 ? (
+        <p>No changes found.</p>
+      ) : (
+        <ul className="space-y-2">
+          {changes.map((change) => (
+            <li key={change.id} className="p-2 border rounded">
+              <Link href={`/impact/${change.id}`}>{change.summary}</Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- switch frontend API requests to use the `X-API-Key` header
- parse change list results and display a message when empty
- show impact diff section only when data exists

## Testing
- `npm test`
- `npm run lint` *(fails: requires @types/react and @types/node, install attempt returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ba60cfca0832e8ec3e5bdadc23cad